### PR TITLE
Feature/storage overwrite param

### DIFF
--- a/Buddy.sln
+++ b/Buddy.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		pipeline-crypto.yml = pipeline-crypto.yml
 		pipeline-storage.yml = pipeline-storage.yml
 		pipeline-testsonly.yml = pipeline-testsonly.yml
+		pipeline-codestyle.yml = pipeline-codestyle.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.AspNetCore.Buddy.Email.SendGrid", "src\Adliance.AspNetCore.Buddy.Email.SendGrid\Adliance.AspNetCore.Buddy.Email.SendGrid.csproj", "{A9402D86-139E-48A6-8444-28C14B7CB310}"

--- a/Buddy.sln
+++ b/Buddy.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		pipeline-datetime.yml = pipeline-datetime.yml
 		pipeline-bulma.yml = pipeline-bulma.yml
 		pipeline-crypto.yml = pipeline-crypto.yml
+		pipeline-storage.yml = pipeline-storage.yml
+		pipeline-testsonly.yml = pipeline-testsonly.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.AspNetCore.Buddy.Email.SendGrid", "src\Adliance.AspNetCore.Buddy.Email.SendGrid\Adliance.AspNetCore.Buddy.Email.SendGrid.csproj", "{A9402D86-139E-48A6-8444-28C14B7CB310}"

--- a/pipeline-buddy.yml
+++ b/pipeline-buddy.yml
@@ -6,6 +6,8 @@ name: ${{ variables.version }}.$(Rev:r)
 resources:
   - repo: self
 
+pr: none
+
 trigger:
   branches:
     include:

--- a/pipeline-codestyle.yml
+++ b/pipeline-codestyle.yml
@@ -6,6 +6,8 @@ name: ${{ variables.version }}.$(Rev:r)
 resources:
   - repo: self
 
+pr: none
+
 trigger:
   branches:
     include:

--- a/pipeline-crypto.yml
+++ b/pipeline-crypto.yml
@@ -6,6 +6,8 @@ name: ${{ variables.version }}.$(Rev:r)
 resources:
   - repo: self
 
+pr: none
+
 trigger:
   branches:
     include:

--- a/pipeline-datetime.yml
+++ b/pipeline-datetime.yml
@@ -6,6 +6,8 @@ name: ${{ variables.version }}.$(Rev:r)
 resources:
   - repo: self
 
+pr: none
+
 trigger:
   branches:
     include:

--- a/pipeline-mailjet.yml
+++ b/pipeline-mailjet.yml
@@ -6,6 +6,8 @@ name: ${{ variables.version }}.$(Rev:r)
 resources:
   - repo: self
 
+pr: none
+
 trigger:
   branches:
     include:

--- a/pipeline-storage.yml
+++ b/pipeline-storage.yml
@@ -14,9 +14,29 @@ trigger:
       - master
   paths:
     include:
-      - /src/Adliance.AspNetCore.Buddy.Bulma
+      - /src/Adliance.AspNetCore.Buddy.Abstractions
+      - /src/Adliance.AspNetCore.Buddy.Storage
+      - /test/Adliance.AspNetCore.Buddy.Storage.Test
 
-stages:   
+stages:
+  - stage: test
+    jobs:
+      - job: run_tests
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: UseDotNet@2
+            displayName: "Install .NET"
+            inputs:
+              version: '7.0.x'
+              packageType: sdk
+          - task: DotNetCoreCLI@2
+            displayName: 'Test'
+            inputs:
+              command: test
+              projects: 'test/Adliance.AspNetCore.Buddy.Storage.Test/*.csproj'
+              arguments: '--configuration Release'    
+    
   - stage: publish
     jobs:
       - job: push_to_nuget
@@ -31,13 +51,13 @@ stages:
           - task: DotNetCoreCLI@2
             displayName: 'Build'
             inputs:
-              projects: 'src/Adliance.AspNetCore.Buddy.Bulma/*.csproj'
+              projects: 'src/Adliance.AspNetCore.Buddy.Storage/*.csproj'
               arguments: '--configuration Release'
           - task: DotNetCoreCLI@2
             displayName: 'Pack'
             inputs:
               command: pack
-              packagesToPack: 'src/Adliance.AspNetCore.Buddy.Bulma/*.csproj'
+              packagesToPack: 'src/Adliance.AspNetCore.Buddy.Storage/*.csproj'
               versioningScheme: byBuildNumber
               configuration: 'Release'
               includeSymbols: true

--- a/pipeline-testsonly.yml
+++ b/pipeline-testsonly.yml
@@ -1,0 +1,33 @@
+name: 0.0.0.$(Rev:r)
+
+resources:
+  - repo: self
+
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - /src
+      - /test
+
+stages:
+  - stage: test
+    jobs:
+      - job: run_tests
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: UseDotNet@2
+            displayName: "Install .NET"
+            inputs:
+              version: '7.0.x'
+              packageType: sdk
+          - task: DotNetCoreCLI@2
+            displayName: 'Test'
+            inputs:
+              command: test
+              projects: 'test/**/*.csproj'
+              arguments: '--configuration Release'    
+   

--- a/src/Adliance.AspNetCore.Buddy.Abstractions/IStorage.cs
+++ b/src/Adliance.AspNetCore.Buddy.Abstractions/IStorage.cs
@@ -13,15 +13,17 @@ namespace Adliance.AspNetCore.Buddy.Abstractions
         /// Stores a blob file <paramref name="bytes"/> with a specified <paramref name="path"/>.
         /// </summary>
         /// <param name="bytes">The file content as byte array.</param>
+        /// <param name="overwrite">Whether the upload should overwrite any files or throw if the file already exists. The default value is true.</param>
         /// <param name="path">The path of the file to store.</param>
-        Task Save(byte[] bytes, params string[] path);
-        
+        Task Save(byte[] bytes, bool overwrite = true, params string[] path);
+
         /// <summary>
         /// Stores a blob file <paramref name="stream"/> with a specified <paramref name="path"/>.
         /// </summary>
         /// <param name="stream">The file content as stream.</param>
+        /// <param name="overwrite">Whether the upload should overwrite any files or throw if the file already exists. The default value is true.</param>
         /// <param name="path">The path of the file to store.</param>
-        Task Save(Stream stream, params string[] path);
+        Task Save(Stream stream, bool overwrite = true, params string[] path);
 
         /// <summary>
         /// Loads a blob file by a specified <paramref name="path"/>.

--- a/src/Adliance.AspNetCore.Buddy.Storage/Adliance.AspNetCore.Buddy.Storage.csproj
+++ b/src/Adliance.AspNetCore.Buddy.Storage/Adliance.AspNetCore.Buddy.Storage.csproj
@@ -16,9 +16,12 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Adliance.AspNetCore.Buddy.Abstractions" Version="6.0.5" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
         <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Adliance.AspNetCore.Buddy.Abstractions\Adliance.AspNetCore.Buddy.Abstractions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Adliance.AspNetCore.Buddy.Storage/AzureStorage.cs
+++ b/src/Adliance.AspNetCore.Buddy.Storage/AzureStorage.cs
@@ -20,21 +20,19 @@ namespace Adliance.AspNetCore.Buddy.Storage
             _configuration = configuration;
         }
 
-        /// <inheritdoc cref="IStorage.Save(byte[],string[])"/>
-        public async Task Save(byte[] bytes, params string[] path)
+        /// <inheritdoc cref="IStorage.Save(byte[],bool,string[])"/>
+        public async Task Save(byte[] bytes, bool overwrite = true, params string[] path)
         {
-            await using (var ms = new MemoryStream())
-            {
-                ms.Write(bytes);
-                ms.Seek(0, SeekOrigin.Begin);
-                await Save(ms, path);
-            }
+            await using var ms = new MemoryStream();
+            ms.Write(bytes);
+            ms.Seek(0, SeekOrigin.Begin);
+            await Save(ms, overwrite, path);
         }
 
-        /// <inheritdoc cref="IStorage.Save(System.IO.Stream,string[])"/>
-        public async Task Save(Stream stream, params string[] path)
+        /// <inheritdoc cref="IStorage.Save(System.IO.Stream,bool,string[])"/>
+        public async Task Save(Stream stream, bool overwrite = true, params string[] path)
         {
-            await GetBlobClient(path).UploadAsync(stream, true);
+            await GetBlobClient(path).UploadAsync(stream, overwrite);
         }
 
         /// <inheritdoc cref="IStorage.Load(string[])"/>

--- a/src/Adliance.AspNetCore.Buddy.Storage/StorageHealthCheck.cs
+++ b/src/Adliance.AspNetCore.Buddy.Storage/StorageHealthCheck.cs
@@ -26,7 +26,7 @@ namespace Adliance.AspNetCore.Buddy.Storage
             {
                 var path = new[] {"healthcheck", "healthcheck_file.bin"};
 
-                await _storage.Save(new byte[] {1, 2, 3}, path);
+                await _storage.Save(new byte[] {1, 2, 3}, true, path);
                 var bytes = await _storage.Load(path);
                 await _storage.Delete(path);
 

--- a/test/Adliance.AspNetCore.Buddy.Storage.Test/StorageTestBase.cs
+++ b/test/Adliance.AspNetCore.Buddy.Storage.Test/StorageTestBase.cs
@@ -28,11 +28,20 @@ namespace Adliance.AspNetCore.Buddy.Storage.Test
             Assert.False(await _storage.Exists(filePath));
             Assert.Null(await _storage.Load(filePath));
 
-            await _storage.Save(new byte[] {1, 2, 3}, filePath);
+            await _storage.Save(new byte[] {1, 2, 3}, true, filePath);
             Assert.True(await _storage.Exists(filePath));
             var bytes = await _storage.Load(filePath);
             Assert.NotNull(bytes);
             Assert.Equal(3, bytes!.Length);
+            
+            await Assert.ThrowsAnyAsync<Exception>(() => _storage.Save(new byte[] {4, 5, 6}, false, filePath));
+            
+            await _storage.Save(new byte[] {4, 5}, true, filePath);
+            
+            Assert.True(await _storage.Exists(filePath));
+            var bytesOverwritten = await _storage.Load(filePath);
+            Assert.NotNull(bytesOverwritten);
+            Assert.Equal(2, bytesOverwritten!.Length);
 
             var uri = await _storage.GetDownloadUrl("nice_name", DateTimeOffset.UtcNow.AddDays(1), filePath);
             Assert.NotNull(uri);
@@ -57,9 +66,9 @@ namespace Adliance.AspNetCore.Buddy.Storage.Test
 
             await using (var ms = new MemoryStream())
             {
-                ms.Write(new byte[] {4, 5, 6, 7});
+                ms.Write(new byte[] {1, 2, 3});
                 ms.Seek(0, SeekOrigin.Begin);
-                await _storage.Save(ms, filePath);
+                await _storage.Save(ms, true, filePath);
             }
 
             Assert.True(await _storage.Exists(filePath));
@@ -68,7 +77,30 @@ namespace Adliance.AspNetCore.Buddy.Storage.Test
             {
                 await _storage.Load(ms, filePath);
                 Assert.NotEmpty(ms.ToArray());
-                Assert.Equal(4, ms.ToArray().Length);
+                Assert.Equal(3, ms.ToArray().Length);
+            }
+            
+            await using (var ms = new MemoryStream())
+            {
+                ms.Write(new byte[] {4, 5});
+                ms.Seek(0, SeekOrigin.Begin);
+                await Assert.ThrowsAnyAsync<Exception>(() => _storage.Save(ms, false, filePath));
+            }
+            
+            await using (var ms = new MemoryStream())
+            {
+                ms.Write(new byte[] {4, 5});
+                ms.Seek(0, SeekOrigin.Begin);
+                await _storage.Save(ms, true, filePath);
+            }
+            
+            Assert.True(await _storage.Exists(filePath));
+
+            await using (var ms = new MemoryStream())
+            {
+                await _storage.Load(ms, filePath);
+                Assert.NotEmpty(ms.ToArray());
+                Assert.Equal(2, ms.ToArray().Length);
             }
 
             var uri = await _storage.GetDownloadUrl("nice_name", DateTimeOffset.UtcNow.AddDays(1), filePath);


### PR DESCRIPTION
Changes:

- **BREAKING** add an overwrite param to the IStorage Save methods - because _params_ are used the new bool parameter must be explicitly set
- directly reference the abstractions project instead of the nuget package

@saxx : This PR has no priority. Is the pipeline for the storage nuget package missing? Are duplicate Abstractions pushes with the same version ignored? Maybe pushing always all packages would be easier to manage?