### PR TITLE
Add Azure Communication Services Emailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bin
 obj
 .idea
 .DS_Store
+
+Buddy.sln.DotSettings.user

--- a/Buddy.sln
+++ b/Buddy.sln
@@ -63,6 +63,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.Buddy.Crypto", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.Buddy.Crypto.Test", "test\Adliance.Buddy.Crypto.Test\Adliance.Buddy.Crypto.Test.csproj", "{E2BB77E5-D5F6-461A-8B3A-5F2B010DFCEA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices", "src\Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices\Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.csproj", "{6CA654DB-8B11-4636-AD23-8D98F0346034}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test", "test\Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test\Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test.csproj", "{5908F0F0-2A74-462B-B01D-A891D8CB3AAB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.Buddy.CodeStyle", "src\Adliance.Buddy.CodeStyle\Adliance.Buddy.CodeStyle.csproj", "{EA4F1356-AF68-4917-B4D6-5BAA552E6339}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -157,6 +163,18 @@ Global
 		{E2BB77E5-D5F6-461A-8B3A-5F2B010DFCEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E2BB77E5-D5F6-461A-8B3A-5F2B010DFCEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E2BB77E5-D5F6-461A-8B3A-5F2B010DFCEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CA654DB-8B11-4636-AD23-8D98F0346034}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CA654DB-8B11-4636-AD23-8D98F0346034}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CA654DB-8B11-4636-AD23-8D98F0346034}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CA654DB-8B11-4636-AD23-8D98F0346034}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5908F0F0-2A74-462B-B01D-A891D8CB3AAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5908F0F0-2A74-462B-B01D-A891D8CB3AAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5908F0F0-2A74-462B-B01D-A891D8CB3AAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5908F0F0-2A74-462B-B01D-A891D8CB3AAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA4F1356-AF68-4917-B4D6-5BAA552E6339}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA4F1356-AF68-4917-B4D6-5BAA552E6339}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA4F1356-AF68-4917-B4D6-5BAA552E6339}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA4F1356-AF68-4917-B4D6-5BAA552E6339}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -171,6 +189,7 @@ Global
 		{B8D2BBAD-1A15-428D-A7EF-D4075EC70958} = {4962C7B7-9835-4FE5-BEEB-DD3F375537B7}
 		{7D656016-35C2-4A72-9137-63439DF3D571} = {4962C7B7-9835-4FE5-BEEB-DD3F375537B7}
 		{E2BB77E5-D5F6-461A-8B3A-5F2B010DFCEA} = {4962C7B7-9835-4FE5-BEEB-DD3F375537B7}
+		{5908F0F0-2A74-462B-B01D-A891D8CB3AAB} = {4962C7B7-9835-4FE5-BEEB-DD3F375537B7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EB86B6DA-4E94-41EF-8CAA-064DE0176535}

--- a/Buddy.sln
+++ b/Buddy.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		pipeline-storage.yml = pipeline-storage.yml
 		pipeline-testsonly.yml = pipeline-testsonly.yml
 		pipeline-codestyle.yml = pipeline-codestyle.yml
+		pipeline-azure-communication.yml = pipeline-azure-communication.yml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adliance.AspNetCore.Buddy.Email.SendGrid", "src\Adliance.AspNetCore.Buddy.Email.SendGrid\Adliance.AspNetCore.Buddy.Email.SendGrid.csproj", "{A9402D86-139E-48A6-8444-28C14B7CB310}"

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Buddy is a set of libraries and utilities with common functionality that is shar
 ### Twilio SMS client
 
 [Adliance.AspNetCore.Buddy.Sms.Twilio](src/Adliance.AspNetCore.Buddy.Sms.Twilio/readme.md)
+
+### Azure Communication Services - E-Mail
+
+[Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices](src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/readme.md)

--- a/pipeline-azure-communication.yml
+++ b/pipeline-azure-communication.yml
@@ -1,0 +1,78 @@
+variables:
+  - template: pipeline-variables.yml
+
+name: ${{ variables.version }}.$(Rev:r)
+
+resources:
+  - repo: self
+
+pr: none
+
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - /src/Adliance.AspNetCore.Buddy.Abstractions
+      - /src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices
+      - /test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test
+      - /pipeline-azure-communication.yml
+
+stages:
+  - stage: test
+    jobs:
+      - job: run_tests
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - task: UseDotNet@2
+            displayName: "Install .NET"
+            inputs:
+              version: '8.0.x'
+              packageType: sdk
+          - task: DotNetCoreCLI@2
+            displayName: 'Test'
+            inputs:
+              command: test
+              projects: 'test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/*.csproj'
+              arguments: '--configuration Release'
+
+#  - stage: publish
+#    jobs:
+#      - job: push_to_nuget
+#        pool:
+#          vmImage: 'ubuntu-latest'
+#        steps:
+#          - task: UseDotNet@2
+#            displayName: "Install .NET"
+#            inputs:
+#              version: '8.0.x'
+#              packageType: sdk
+#          - task: DotNetCoreCLI@2
+#            displayName: 'Build'
+#            inputs:
+#              projects: 'src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/*.csproj'
+#              arguments: '--configuration Release'
+#          - task: DotNetCoreCLI@2
+#            displayName: 'Pack Dependency Abstractions'
+#            inputs:
+#              command: pack
+#              packagesToPack: 'src/Adliance.AspNetCore.Buddy.Abstractions/*.csproj'
+#              versioningScheme: byBuildNumber
+#              configuration: 'Release'
+#              includeSymbols: true
+#          - task: DotNetCoreCLI@2
+#            displayName: 'Pack'
+#            inputs:
+#              command: pack
+#              packagesToPack: 'src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/*.csproj'
+#              versioningScheme: byBuildNumber
+#              configuration: 'Release'
+#              includeSymbols: true
+#          - task: NuGetCommand@2
+#            displayName: 'NuGet Push'
+#            inputs:
+#              command: push
+#              nuGetFeedType: external
+#              publishFeedCredentials: 'Public NuGet'

--- a/pipeline-testsonly.yml
+++ b/pipeline-testsonly.yml
@@ -29,6 +29,11 @@ stages:
             inputs:
               version: '7.0.x'
               packageType: sdk
+          - task: UseDotNet@2
+            displayName: "Install .NET 8"
+            inputs:
+              version: '8.0.x'
+              packageType: sdk
           - task: DotNetCoreCLI@2
             displayName: 'Test'
             inputs:

--- a/src/Adliance.AspNetCore.Buddy.Abstractions/IEmailConfiguration.cs
+++ b/src/Adliance.AspNetCore.Buddy.Abstractions/IEmailConfiguration.cs
@@ -17,7 +17,7 @@ namespace Adliance.AspNetCore.Buddy.Abstractions
         string SenderAddress { get; }
 
         /// <summary>
-        /// The "reply to" address (can be different from the sender address.
+        /// The "reply to" address (can be different from the sender address).
         /// </summary>
         string ReplyToAddress { get; }
         

--- a/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.csproj
+++ b/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      <PackageReference Include="Azure.Communication.Email" Version="1.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Adliance.AspNetCore.Buddy.Abstractions\Adliance.AspNetCore.Buddy.Abstractions.csproj" />
+      <ProjectReference Include="..\Adliance.Buddy.CodeStyle\Adliance.Buddy.CodeStyle.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/AzureCommunicationEmailer.cs
+++ b/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/AzureCommunicationEmailer.cs
@@ -1,0 +1,77 @@
+﻿using Adliance.AspNetCore.Buddy.Abstractions;
+using Azure;
+using Azure.Communication.Email;
+using Microsoft.AspNetCore.StaticFiles;
+
+namespace Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices;
+
+public class AzureCommunicationEmailer : IEmailer
+{
+    private readonly IAzureCommunicationConfiguration _azureCommunicationConfig;
+    private readonly IEmailConfiguration _emailConfig;
+    
+    public AzureCommunicationEmailer(IAzureCommunicationConfiguration azureCommunicationConfig, IEmailConfiguration emailConfig)
+    {
+        _azureCommunicationConfig = azureCommunicationConfig;
+        _emailConfig = emailConfig;
+    }
+    
+    public async Task Send(string recipientAddress, string subject, string htmlBody, string textBody,
+        params IEmailAttachment[] attachments)
+    {
+        await Send(_emailConfig.SenderName, _emailConfig.SenderAddress, _emailConfig.ReplyToAddress, "", recipientAddress, subject, htmlBody, textBody, attachments);
+    }
+
+    public async Task Send(string senderName, string senderAddress, string replyTo, string recipientName, string recipientAddress,
+        string subject, string htmlBody, string textBody, params IEmailAttachment[] attachments)
+    {
+        if (string.IsNullOrWhiteSpace(recipientAddress)) throw new ArgumentOutOfRangeException(nameof(recipientAddress));
+
+        if (_emailConfig.Disable)
+            return;
+        
+        string endpoint = _azureCommunicationConfig.Endpoint;
+        var credential = new AzureKeyCredential(_azureCommunicationConfig.AccessKey);
+        EmailClient client = new EmailClient(new Uri(endpoint), credential);
+
+        
+        var to = GetRecipient(recipientName, recipientAddress);
+
+        var content = new EmailContent(subject)
+        {
+            PlainText = textBody,
+            Html = htmlBody
+        };
+
+        var email = new EmailMessage(_emailConfig.SenderAddress, to, content)
+        {
+            ReplyTo = { new EmailAddress(replyTo) },
+            UserEngagementTrackingDisabled = _azureCommunicationConfig.UserEngagementTrackingDisabled,
+        };
+        
+        foreach (var attachment in attachments)
+        {
+            new FileExtensionContentTypeProvider().TryGetContentType(attachment.Filename, out var contentType);
+            email.Attachments.Add(new EmailAttachment(attachment.Filename, contentType ?? "application/octet-stream", new BinaryData(attachment.Bytes)));
+        }
+
+        try
+        {
+            await client.SendAsync(WaitUntil.Completed, email);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Sending email via Azure Communication Services failed: {ex.Message}", ex);
+        }
+    }
+    
+    private EmailRecipients GetRecipient(string recipientName, string recipientAddress)
+    {
+        if (!string.IsNullOrWhiteSpace(_emailConfig.RedirectAllEmailsTo))
+            return new EmailRecipients([new EmailAddress(_emailConfig.RedirectAllEmailsTo)]);
+
+        return string.IsNullOrWhiteSpace(recipientName)
+            ? new EmailRecipients([new EmailAddress(recipientAddress)])
+            : new EmailRecipients([new EmailAddress(recipientAddress, recipientName)]);
+    }
+}

--- a/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/Extensions/BuddyServiceCollectionExtensions.cs
+++ b/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/Extensions/BuddyServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+﻿using Adliance.AspNetCore.Buddy.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable UnusedType.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Extensions
+{
+    public static class BuddyServiceCollectionExtensions
+    {
+        public static IBuddyServiceCollection AddAzureCommunicationEmail(
+            this IBuddyServiceCollection buddyServices,
+            IEmailConfiguration emailConfiguration,
+            IAzureCommunicationConfiguration azureCommunicationConfiguration)
+        {
+            buddyServices.Services.AddSingleton(emailConfiguration);
+            buddyServices.Services.AddSingleton(azureCommunicationConfiguration);
+            return AddAzureCommunicationEmail(buddyServices);
+        }
+
+        public static IBuddyServiceCollection AddAzureCommunicationEmail(
+            this IBuddyServiceCollection buddyServices,
+            IConfigurationSection emailConfigurationSection,
+            IConfigurationSection azureCommunicationConfigurationSection)
+        {
+            var emailOptions = emailConfigurationSection.Get<DefaultEmailConfiguration>() ?? throw new Exception($"Unable to load email configuration from {emailConfigurationSection.Path}.");
+            buddyServices.Services.Configure<IEmailConfiguration>(emailConfigurationSection);
+
+            var azureCommunicationOptions = azureCommunicationConfigurationSection.Get<DefaultAzureCommunicationConfiguration>()?? throw new Exception($"Unable to load azure communication configuration from {azureCommunicationConfigurationSection.Path}.");
+            buddyServices.Services.Configure<IAzureCommunicationConfiguration>(azureCommunicationConfigurationSection);
+
+            return AddAzureCommunicationEmail(buddyServices, emailOptions, azureCommunicationOptions);
+        }
+
+        public static IBuddyServiceCollection AddAzureCommunicationEmail(
+            this IBuddyServiceCollection buddyServices)
+        {
+            buddyServices.Services.AddTransient<IEmailer, AzureCommunicationEmailer>();
+            return buddyServices;
+        }
+    }
+}

--- a/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/IAzureCommunicationConfiguration.cs
+++ b/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/IAzureCommunicationConfiguration.cs
@@ -1,16 +1,44 @@
 namespace Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices;
 
+/// <summary>
+/// Specifies the configuration format.
+/// </summary>
 public interface IAzureCommunicationConfiguration
 {
+    /// <summary>
+    /// The API endpoint to use.
+    /// </summary>
+    /// <remarks>
+    /// This is unique for every tenant / app service instance.
+    /// </remarks>
     string Endpoint { get; }
+    
+    /// <summary>
+    /// The access key for authentication.
+    /// </summary>
     string AccessKey { get; }
+    
+    /// <summary>
+    /// Disable open/click tracking for end user mails.
+    /// </summary>
+    /// <remarks>
+    /// Also needs to be enabled in for the send domain resource in the Azure portal.
+    /// </remarks>
     bool UserEngagementTrackingDisabled { get; }
 }
 
 // ReSharper disable once UnusedType.Global
+/// <summary>
+/// Default configuration for Azure Communication emailer.
+/// </summary>
 public class DefaultAzureCommunicationConfiguration : IAzureCommunicationConfiguration
 {
-    public string Endpoint { get; init; } = "";
-    public string AccessKey { get; init; } = "";
+    /// <inheritdoc cref="IAzureCommunicationConfiguration.Endpoint"/>
+    public string Endpoint { get; init; } = string.Empty;
+    
+    /// <inheritdoc cref="IAzureCommunicationConfiguration.AccessKey"/>
+    public string AccessKey { get; init; } = string.Empty;
+    
+    /// <inheritdoc cref="IAzureCommunicationConfiguration.UserEngagementTrackingDisabled"/>
     public bool UserEngagementTrackingDisabled { get; init; } = true;
 }

--- a/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/IAzureCommunicationConfiguration.cs
+++ b/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/IAzureCommunicationConfiguration.cs
@@ -1,0 +1,16 @@
+namespace Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices;
+
+public interface IAzureCommunicationConfiguration
+{
+    string Endpoint { get; }
+    string AccessKey { get; }
+    bool UserEngagementTrackingDisabled { get; }
+}
+
+// ReSharper disable once UnusedType.Global
+public class DefaultAzureCommunicationConfiguration : IAzureCommunicationConfiguration
+{
+    public string Endpoint { get; init; } = "";
+    public string AccessKey { get; init; } = "";
+    public bool UserEngagementTrackingDisabled { get; init; } = true;
+}

--- a/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/readme.md
+++ b/src/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices/readme.md
@@ -1,0 +1,56 @@
+﻿# Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices
+
+The Azure Communication Buddy makes sending E-Mail easy. Find more detailed information on the [Azure website](https://learn.microsoft.com/en-us/azure/communication-services/concepts/email/prepare-email-communication-resource).
+
+## Setup library in an ASP.NET project
+
+The `IBuddyServiceCollection` of the `Adliance.AspNetCore.Buddy.Abstractions` package offers the `AddBuddy` method, which provides `AddAzureCommunicationEmail` extensions to add the E-Mail services.
+
+```c#
+using Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices;
+
+// ...
+
+public void ConfigureServices(IServiceCollection services)
+{
+  //...
+  services.AddBuddy()
+    .AddAzureCommunicationEmail(Configuration.GetSection("E-Mail"),
+      Configuration.GetSection("Azure-Communication-Email"))    
+  //...
+ }
+```
+
+### Configuration (appsettings.json)
+
+Add a section in the configuration of your project and add following configuration:
+
+```json
+{
+  "E-Mail": {
+    "SenderName": "unused (always taken from config in Azure)",
+    "SenderAddress": "sender@example.com",
+    "ReplyToAddress": "reply@example.com",
+    "RedirectAllEmailsTo": "",
+    "Disable": false
+  },
+  "Azure-Communication-Email": {
+    "Endpoint": "https://<your-communication-service-name>.<region>.communication.azure.com/",
+    "AccessKey": "your-access-key",
+    "UserEngagementTrackingDisabled": false
+  }
+}
+```
+
+Look up your API credentials in your Azure portal.
+
+## Usage of library
+
+This code sample shows the usage of the Azure Communication email client. Just call the `Send` method providing a recipient, subject and a body.
+```c#
+IEmailer emailer = new AzureCommunicationEmailer(azureCommunicationConfig, emailConfig);
+await emailer.Send(recipientAddress,
+            "Descriptive subject line",
+            "This is the <b>HTML</b> body.",
+            "This is the **Text** body.");
+```

--- a/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test.csproj
+++ b/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices\Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/AzureCommunicationEmailerTest.cs
+++ b/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/AzureCommunicationEmailerTest.cs
@@ -1,0 +1,55 @@
+using Xunit;
+
+namespace Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test;
+
+public class AzureCommunicationEmailerTest
+{
+    private readonly string _testRecipientAddress =
+        Utils.GetEnvironmentVariable("Adliance_Buddy_Tests__AzureCommunication_RecipientAddress");
+    
+    [Fact]
+    public async Task CanSendEmailWithoutAttachments()
+    {
+        var mailer = new AzureCommunicationEmailer(new MockedAzureCommunicationConfiguration(), new MockedEmailConfiguration());
+
+        await mailer.Send(
+            _testRecipientAddress,
+            "Unit Test (no attachments)",
+            "This is the <b>HTML</b> body.",
+            "This is the **Text** body.");
+    }
+    
+    [Fact]
+    public async Task ThrowsExceptionOnInvalidAccessKey()
+    {
+        var invalidConfig = new MockedAzureCommunicationConfiguration()
+        {
+            AccessKey = Convert.ToBase64String("invalid"u8.ToArray())
+        };
+        
+        var mailer = new AzureCommunicationEmailer(invalidConfig, new MockedEmailConfiguration());
+
+        var exp = await Assert.ThrowsAsync<Exception>(async () => await mailer.Send(
+            _testRecipientAddress,
+            "Unit Test (no attachments)",
+            "This is the <b>HTML</b> body.",
+            "This is the **Text** body."));
+        
+        Assert.Contains("Denied", exp.Message);
+        Assert.Contains("Unauthorized", exp.Message);
+    }
+
+    [Fact]
+    public async Task CanSendEmailWithAttachments()
+    {
+        var mailer = new AzureCommunicationEmailer(new MockedAzureCommunicationConfiguration(), new MockedEmailConfiguration());
+        
+        await mailer.Send(
+            _testRecipientAddress,
+            "Unit Test (with attachments)",
+            "This is the <b>HTML</b> body.<br /><br />And <a href='https://www.igevia.com'>this</a> is a link.",
+            "This is the **Text** body.",
+            new MockedEmailAttachment("textfile.txt", new byte[] {1}),
+            new MockedEmailAttachment("musicfile.mp3", new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    }
+}

--- a/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/Mocks.cs
+++ b/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/Mocks.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using Adliance.AspNetCore.Buddy.Abstractions;
+
+namespace Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test;
+
+// Environment variables for local testing can be set with [Solution personal layer](https://www.jetbrains.com/help/rider/Sharing_Configuration_Options.html#solution-personal-layer)
+// settings for [Test Runner](https://www.jetbrains.com/help/rider/Reference__Options__Tools__Unit_Testing__Test_Runner.html#environment-variables)
+public class MockedAzureCommunicationConfiguration : IAzureCommunicationConfiguration
+{
+    public string Endpoint => Utils.GetEnvironmentVariable("Adliance_Buddy_Tests__AzureCommunication_Endpoint");
+    public string AccessKey { get; init; } =  Utils.GetEnvironmentVariable("Adliance_Buddy_Tests__AzureCommunication_AccessKey");
+
+    public bool UserEngagementTrackingDisabled => true;
+}
+
+public class MockedEmailConfiguration : IEmailConfiguration
+{
+    /// <summary>
+    /// Azure Communication Services SDK does not support setting a sender name.
+    /// It always uses the display name configured in the communication service
+    /// domain -> MailFrom address.
+    /// </summary>
+    public string SenderName => "not used";
+    public string SenderAddress => "DoNotReply@adliance.dev";
+    public string ReplyToAddress => "hannes.sachsenhofer@adliance.net";
+    public string RedirectAllEmailsTo => "";
+    public bool Disable => false;
+}
+
+public class MockedEmailAttachment : IEmailAttachment
+{
+    public MockedEmailAttachment(string fileName, byte[] bytes)
+    {
+        Filename = fileName;
+        Bytes = bytes;
+    }
+
+    public string Filename { get; set; }
+    public byte[] Bytes { get; set; }
+}

--- a/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/Utils.cs
+++ b/test/Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test/Utils.cs
@@ -1,0 +1,22 @@
+using System.Text;
+
+namespace Adliance.AspNetCore.Buddy.Email.AzureCommunicationServices.Test;
+
+public static class Utils
+{
+    public static string GetEnvironmentVariable(string name)
+    {
+        return Environment.GetEnvironmentVariable(name)
+               ?? Environment.GetEnvironmentVariable(name.ToUpper())
+               ?? Environment.GetEnvironmentVariable(name.ToLower())
+               ?? throw BuildEnvironmentVariableException(name);
+    }
+
+    private static Exception BuildEnvironmentVariableException(string name)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Environment variable \"{name}\" missing. Available environment variables are:");
+        foreach (var o in Environment.GetEnvironmentVariables()) sb.AppendLine(o.ToString());
+        throw new Exception(sb.ToString());
+    }
+}


### PR DESCRIPTION
Health check is not implemented, because the SDK has no sandbox option.

I tried to create a workaround with the cancellation token, but then we only receive a status cancelled, which is not helpful.

When sending a message, it is possible to either wait until the operation was started, or also completed. We could create a message in the health check, wait until it started (without an exception), and then cancel the operation.

Depending on the service communication delays, this might send a real mail, which might not be what we want.

If we don't care, we can create a mailbox, which just discards our health check emails. However, this option will eat into our daily send limits.

I commented out the NuGet publishing, until we have decided on the health check implementation.