### PR TITLE
update codestyle buddy readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ Buddy.sln.DotSettings.user
 
 node_modules
 src/Adliance.AspNetCore.Buddy.Highcharts/.editorconfig
+
+## Ignore .editorconfig files from nuget package
+
+src/**/.editorconfig
+test/**/.editorconfig

--- a/src/Adliance.Buddy.QrCode/Adliance.Buddy.QrCode.csproj
+++ b/src/Adliance.Buddy.QrCode/Adliance.Buddy.QrCode.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
       <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.3" />
       <PackageReference Include="ZXing.Net" Version="0.16.9" />
     </ItemGroup>


### PR DESCRIPTION
- the readme is updated and extended by dotnet format and CI relevant information
- ImageSharp nuget package is updated because of security vulnerability
- .editorconfig files are added to .gitignore