### PR TITLE
Feature/multiple file upload

### DIFF
--- a/src/Adliance.AspNetCore.Buddy.Bulma/TagHelpers/FieldTagHelper.cs
+++ b/src/Adliance.AspNetCore.Buddy.Bulma/TagHelpers/FieldTagHelper.cs
@@ -32,6 +32,9 @@ public class FieldTagHelper : TagHelper
     [HtmlAttributeName("multi-line")] public bool MultiLine { get; set; }
     [HtmlAttributeName("file-upload")] public bool FileUpload { get; set; }
     [HtmlAttributeName("file-upload-accept")] public string? FileUploadAcceptFilter { get; set; }
+    [HtmlAttributeName("multiple-file-upload")] public bool MultipleFileUpload { get; set; }
+    [HtmlAttributeName("multiple-file-upload-files-label")]
+    public string? MultipleFileUploadFilesLabel { get; set; } = "Files";
     [HtmlAttributeName("checkboxes")] public bool Checkboxes { get; set; }
     [HtmlAttributeName("rows")] public int Rows { get; set; } = 6;
     [HtmlAttributeName("password")] public bool Password { get; set; }
@@ -201,16 +204,33 @@ public class FieldTagHelper : TagHelper
                 placeholder = Placeholder ?? ""
             });
         }
-        else if (FileUpload)
+        else if (FileUpload || MultipleFileUpload)
         {
             builder.AppendHtml($"<div class=\"file has-name is-fullwidth{SizeClass}\"><label class=\"file-label\">");
-            builder.AppendHtml(_htmlGenerator.GenerateTextBox(ViewContext, For?.ModelExplorer, For?.Name, For?.ModelExplorer.Model, null, new
+
+            if (FileUpload)
             {
-                type = "file",
-                @class = "file-input",
-                accept = FileUploadAcceptFilter,
-                onchange = "if (this.files.length > 0) { this.closest(\"div.file\").querySelector(\"span.file-name\").innerText = this.files[0].name; }"
-            }));
+                builder.AppendHtml(_htmlGenerator.GenerateTextBox(ViewContext, For?.ModelExplorer, For?.Name,
+                    For?.ModelExplorer.Model, null, new
+                    {
+                        type = "file",
+                        @class = "file-input",
+                        accept = FileUploadAcceptFilter,
+                        onchange = "if (this.files.length > 0) { this.closest(\"div.file\").querySelector(\"span.file-name\").innerText = this.files[0].name; }"
+                    }));
+            }
+            else
+            {
+                builder.AppendHtml(_htmlGenerator.GenerateTextBox(ViewContext, For?.ModelExplorer, For?.Name, For?.ModelExplorer.Model, null, new
+                {
+                    type = "file",
+                    @class = "file-input",
+                    accept = FileUploadAcceptFilter,
+                    multiple = "multiple",
+                    onchange = $"if (this.files.length > 0) {{ this.closest(\"div.file\").querySelector(\"span.file-name\").innerText = this.files.length > 1 ? `${{this.files.length}} {MultipleFileUploadFilesLabel}` : this.files[0].name; }}"
+                }));
+            }
+
             builder.AppendHtml($"<span class=\"file-cta\"><span class=\"file-label\">{Placeholder}</span></span>");
             builder.AppendHtml("<span class=\"file-name\"></span></label></div>");
         }

--- a/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml
+++ b/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml
@@ -55,7 +55,7 @@
                 <field asp-for="DateValue" label="Date" help="Date with prepended text" prepend="prepend"/>
             </div>
             <div class="column">
-                <field asp-for="FileValue" label="Files" help="Renders a file upload" placeholder="Select file" file-upload/>
+                <field asp-for="FileValue" label="File" help="Renders a file upload" placeholder="Select file" file-upload/>
             </div>
         </div>
         <div class="columns">
@@ -69,7 +69,7 @@
                 <field asp-for="DateValue" label="Date" help="Medium date with prepended text" size="Medium" prepend="prepend"/>
             </div>
             <div class="column">
-                <field asp-for="FileValues" label="File" help="Renders a large multiple file upload with a custom files label" size="Large" 
+                <field asp-for="FileValues" label="Files" help="Renders a large multiple file upload with a custom files label" size="Large" 
                        file-upload-accept=".xls,.xlsx" placeholder="Select file" multiple-file-upload multiple-file-upload-files-label="Dateien"/>
             </div>
         </div>

--- a/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml
+++ b/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml
@@ -55,7 +55,7 @@
                 <field asp-for="DateValue" label="Date" help="Date with prepended text" prepend="prepend"/>
             </div>
             <div class="column">
-                <field asp-for="FileValue" label="File" help="Renders a file upload" placeholder="Select file" file-upload/>
+                <field asp-for="FileValue" label="Files" help="Renders a file upload" placeholder="Select file" file-upload/>
             </div>
         </div>
         <div class="columns">
@@ -69,7 +69,8 @@
                 <field asp-for="DateValue" label="Date" help="Medium date with prepended text" size="Medium" prepend="prepend"/>
             </div>
             <div class="column">
-                <field asp-for="FileValue" label="File" help="Renders a large file upload" size="Large" file-upload-accept=".xls,.xlsx" placeholder="Select file" file-upload/>
+                <field asp-for="FileValues" label="File" help="Renders a large multiple file upload with a custom files label" size="Large" 
+                       file-upload-accept=".xls,.xlsx" placeholder="Select file" multiple-file-upload multiple-file-upload-files-label="Dateien"/>
             </div>
         </div>
         <div class="columns">

--- a/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml.cs
+++ b/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml.cs
@@ -10,6 +10,7 @@ public class IndexModel : PageModel
     [BindProperty] public string PasswordValue { get; set; } = "My initial password";
     [BindProperty] public string TextareaValue { get; set; } = $"My initial{Environment.NewLine}textarea value";
     [BindProperty] public IFormFile? FileValue { get; set; }
+    [BindProperty] public IFormFile[]? FileValues { get; set; }
     [BindProperty] public DateTime DateValue { get; set; } = DateTime.Now;
     [BindProperty] public bool CheckboxValue { get; set; }
 


### PR DESCRIPTION
- Extend Bulma `FieldTagHelper` by `multiple-file-upload` attribute to support the upload of multiple files.
- With the additional attribute `multiple-file-upload-files-label` a label for showing the count of the selected files can be set. The default value is "Files".

Example of using the `multiple-file-upload` attribute (`multiple-file-upload-files-label` is here set to "Dateien"):
![image](https://github.com/user-attachments/assets/7ccf20c2-0916-4660-9b8d-c44451c974ff)
