### PR TITLE
Support range attributes for date and number input fields

### DIFF
--- a/src/Adliance.AspNetCore.Buddy.Bulma/TagHelpers/FieldTagHelper.cs
+++ b/src/Adliance.AspNetCore.Buddy.Bulma/TagHelpers/FieldTagHelper.cs
@@ -40,6 +40,9 @@ public class FieldTagHelper : TagHelper
     [HtmlAttributeName("rows")] public int Rows { get; set; } = 6;
     [HtmlAttributeName("password")] public bool Password { get; set; }
     [HtmlAttributeName("number")] public bool Number { get; set; }
+    [HtmlAttributeName("step")] public string? Step { get; set; }
+    [HtmlAttributeName("min")] public string? Min { get; set; }
+    [HtmlAttributeName("max")] public string? Max { get; set; }
     /// <summary>
     /// Defines the size of the field. Available for all types, except checkboxes.
     /// </summary>
@@ -236,11 +239,11 @@ public class FieldTagHelper : TagHelper
         }
         else if (IsDateTime)
         {
-            control = _htmlGenerator.GenerateTextBox(ViewContext, For?.ModelExplorer, For?.Name, (For?.ModelExplorer.Model as DateTime?)?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), null, new { type = "date", @class = $"input{SizeClass}", placeholder = Placeholder ?? "" });
+            control = _htmlGenerator.GenerateTextBox(ViewContext, For?.ModelExplorer, For?.Name, (For?.ModelExplorer.Model as DateTime?)?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), null, new { type = "date", @class = $"input{SizeClass}", placeholder = Placeholder ?? "", min = Min, max = Max });
         }
         else if (Number)
         {
-            control = _htmlGenerator.GenerateTextBox(ViewContext, For?.ModelExplorer, For?.Name, For?.ModelExplorer.Model, null, new { type = "number", @class = $"input{SizeClass}", placeholder = Placeholder ?? "" });
+            control = _htmlGenerator.GenerateTextBox(ViewContext, For?.ModelExplorer, For?.Name, For?.ModelExplorer.Model, null, new { type = "number", @class = $"input{SizeClass}", placeholder = Placeholder ?? "", step = Step, min = Min, max = Max });
         }
         else
         {

--- a/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml
+++ b/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml
@@ -24,10 +24,10 @@
                 <field asp-for="PasswordValue" label="Password" help="Renders a password field" password icon="fa fa-trash" auto-complete="false"/>
             </div>
             <div class="column">
-                <field asp-for="DateValue" label="Date" help="Renders a date field"/>
+                <field asp-for="DateValue" label="Date" help="Renders a date field" min="2025-01-01" max="2025-12-31"/>
             </div>
             <div class="column">
-                <field asp-for="NumberValue" label="Date" help="Renders a number field" number/>
+                <field asp-for="NumberValue" label="Number" help="Renders a number field" number step="0.01" min="0" max="1"/>
             </div>
         </div>
         <div class="columns">
@@ -41,7 +41,7 @@
                 <field asp-for="DateValue" label="Date" size="Medium" help="Renders a medium date field"/>
             </div>
             <div class="column">
-                <field asp-for="NumberValue" label="Date" size="Large" help="Renders a large number field" number/>
+                <field asp-for="NumberValue" label="Number" size="Large" help="Renders a large number field" number/>
             </div>
         </div>
         <div class="columns">

--- a/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml.cs
+++ b/test/Adliance.AspNetCore.Buddy.Bulma.Test/Pages/Index.cshtml.cs
@@ -6,7 +6,7 @@ namespace Adliance.AspNetCore.Buddy.Bulma.Test.Pages;
 public class IndexModel : PageModel
 {
     [BindProperty] public string InputValue { get; set; } = "My initial input value";
-    [BindProperty] public int NumberValue { get; set; } = 123;
+    [BindProperty] public double NumberValue { get; set; } = 123;
     [BindProperty] public string PasswordValue { get; set; } = "My initial password";
     [BindProperty] public string TextareaValue { get; set; } = $"My initial{Environment.NewLine}textarea value";
     [BindProperty] public IFormFile? FileValue { get; set; }


### PR DESCRIPTION
Add support for the `step`, `min`, and `max` attributes for number and date fields.