### PR TITLE
Testing: support prebuilt images

### DIFF
--- a/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerHelper.cs
+++ b/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerHelper.cs
@@ -14,7 +14,8 @@ public static class ContainerHelper
                 Url = options.UseLocalAppInstead,
                 Client = new HttpClient
                 {
-                    BaseAddress = options.UseLocalAppInstead
+                    BaseAddress = options.UseLocalAppInstead,
+                    Timeout = options.ClientTimeout
                 }
             };
         }
@@ -56,7 +57,8 @@ public static class ContainerHelper
         result.Url = new UriBuilder("http", result.Container.Hostname, result.Container.GetMappedPublicPort(options.Port)).Uri;
         result.Client = new HttpClient
         {
-            BaseAddress = result.Url
+            BaseAddress = result.Url,
+            Timeout = options.ClientTimeout
         };
         return result;
     }

--- a/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerHelper.cs
+++ b/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerHelper.cs
@@ -21,16 +21,19 @@ public static class ContainerHelper
 
         var result = new ContainerResult
         {
-            Image = new DockerImage(options.Repository, "localhost", "latest")
+            Image = options.Image ?? new DockerImage(options.Repository, "localhost", "latest")
         };
 
-        await new ImageFromDockerfileBuilder()
-            .WithName(result.Image)
-            .WithDockerfileDirectory(options.DockerFileDirectory)
-            .WithDockerfile(options.DockerFileName)
-            .Build()
-            .CreateAsync()
-            .ConfigureAwait(false);
+        if (options.Image == null)
+        {
+            await new ImageFromDockerfileBuilder()
+                .WithName(result.Image)
+                .WithDockerfileDirectory(options.DockerFileDirectory)
+                .WithDockerfile(options.DockerFileName)
+                .Build()
+                .CreateAsync()
+                .ConfigureAwait(false);
+        }
 
         var webContainerBuilder = new ContainerBuilder(result.Image)
             .WithNetwork(options.Network)
@@ -45,6 +48,8 @@ public static class ContainerHelper
         {
             webContainerBuilder = webContainerBuilder.WithEnvironment(key, value);
         }
+
+        if (options.ConfigureContainer != null) webContainerBuilder = options.ConfigureContainer.Invoke(webContainerBuilder);
 
         result.Container = webContainerBuilder.Build();
         await result.Container.StartAsync().ConfigureAwait(false);

--- a/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerOptions.cs
+++ b/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerOptions.cs
@@ -76,6 +76,11 @@ public class ContainerOptions
     public Func<ContainerBuilder, ContainerBuilder>? ConfigureContainer { get; set; }
 
     /// <summary>
+    /// The timeout for HTTP requests to the container.
+    /// </summary>
+    public TimeSpan ClientTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Set this to a local URL (eg. of an already running web app); if this value is set, then no container will be started.
     /// This is useful for local debugging scenarios.
     /// </summary>

--- a/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerOptions.cs
+++ b/src/Adliance.AspNetCore.Buddy.Testing.Shared/Containers/ContainerOptions.cs
@@ -1,5 +1,6 @@
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Images;
 using DotNet.Testcontainers.Networks;
 using Microsoft.Extensions.Logging;
 
@@ -7,34 +8,72 @@ namespace Adliance.AspNetCore.Buddy.Testing.Shared.Containers;
 
 public class ContainerOptions
 {
-    public static ContainerOptions Clone(string repository, ContainerOptions options)
+    /// <summary>
+    /// The docker network to use. If null, a new network will be created.
+    /// </summary>
+    public INetwork? Network { get; set; }
+
+    /// <summary>
+    /// A custom image to use. Might be a DockerHub image or a local image.
+    /// </summary>
+    public DockerImage? Image { get; set; }
+
+    /// <summary>
+    /// The Image name used when building the image from a dockerfile. In that case, the registry is always localhost;
+    /// so the resulting full image name is localhost/[repository]:latest.
+    /// </summary>
+    public string Repository { get; set; } = "webapp";
+
+    /// <summary>
+    /// The name of the dockerfile to use. Only used if <see cref="Image"/> is null.
+    /// </summary>
+    public string DockerFileName { get; set; } = "dockerfile";
+
+    /// <summary>
+    /// The location of the dockerfile to use. Only used if <see cref="Image"/> is null.
+    /// </summary>
+    public string DockerFileDirectory { get; set; } = "./";
+
+    /// <summary>
+    /// The network alias under which the container is reachable.
+    /// </summary>
+    public string NetworkAlias { get; set; } = "webapp";
+
+    /// <summary>
+    /// A dictionary of environment variables to set in the container.
+    /// </summary>
+    public Dictionary<string, string?> Configuration { get; set; } = new();
+
+    /// <summary>
+    /// The wait strategy to determine when the container is ready.
+    /// By default, the container is ready when the internal TCP port is available.
+    /// </summary>
+    public IWaitForContainerOS? WaitStrategy
     {
-        var result = new ContainerOptions
-        {
-            Repository = repository,
-            DockerFileName = options.DockerFileName,
-            DockerFileDirectory = options.DockerFileDirectory,
-            WaitStrategy = options.WaitStrategy,
-            Network = options.Network,
-            Configuration = options.Configuration,
-            NetworkAlias = options.NetworkAlias,
-            Port = options.Port,
-            Logger = options.Logger,
-            DbConnectionStringConfigurationKey = options.DbConnectionStringConfigurationKey
-        };
-        return result;
+        get => field ?? Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(Port);
+        set;
     }
 
-    public INetwork? Network { get; set; }
-    public string Repository { get; set; } = "webapp";
-    public string DockerFileName { get; set; } = "dockerfile";
-    public string DockerFileDirectory { get; set; } = "./";
-    public string NetworkAlias { get; set; } = "webapp";
-    public Dictionary<string, string?> Configuration { get; set; } = new();
-    public IWaitForContainerOS? WaitStrategy { get; set; } = Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(80);
+    /// <summary>
+    /// The port on which the service in the container is listening to.
+    /// </summary>
     public int Port { get; set; } = 80;
+
+    /// <summary>
+    /// A logger to direct the output of the container to.
+    /// </summary>
     public ILogger Logger { get; set; } = new InMemoryLogger();
+
+    /// <summary>
+    /// The configuration key under which the database connection string is stored.
+    /// Will be dynamically added to <see cref="Configuration"/> if a <see cref="BuddyFixtureOptions{TEntryPoint}.Database"/> is configured.
+    /// </summary>
     public string DbConnectionStringConfigurationKey { get; set; } = "";
+
+    /// <summary>
+    /// A function to configure the container builder before the container is started.
+    /// </summary>
+    public Func<ContainerBuilder, ContainerBuilder>? ConfigureContainer { get; set; }
 
     /// <summary>
     /// Set this to a local URL (eg. of an already running web app); if this value is set, then no container will be started.

--- a/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/Test/WithMockContainer/InContainerOptions.cs
+++ b/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/Test/WithMockContainer/InContainerOptions.cs
@@ -1,0 +1,24 @@
+using Adliance.AspNetCore.Buddy.Testing.Shared;
+using Adliance.AspNetCore.Buddy.Testing.Shared.Containers;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Images;
+
+namespace Adliance.AspNetCore.Buddy.Testing.v3.Test.Test.WithMockContainer;
+
+public class InContainerOptions : BuddyFixtureOptions<Program>
+{
+    public InContainerOptions()
+    {
+        InContainer.Add(new ContainerOptions
+        {
+            Image = new DockerImage("mockoon/cli:latest"),
+            ConfigureContainer = builder =>
+                builder
+                    .WithResourceMapping(
+                        Path.Combine(CommonDirectoryPath.GetProjectDirectory().DirectoryPath, "api-mock.json"),
+                        "/config")
+                    .WithEntrypoint("mockoon-cli", "start", "--data", "/config/api-mock.json"),
+            Port = 3000
+        });
+    }
+}

--- a/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/Test/WithMockContainer/WithMockContainerFixture.cs
+++ b/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/Test/WithMockContainer/WithMockContainerFixture.cs
@@ -1,0 +1,6 @@
+using Adliance.AspNetCore.Buddy.Testing.Shared;
+
+namespace Adliance.AspNetCore.Buddy.Testing.v3.Test.Test.WithMockContainer;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public class WithMockContainerFixture<TOptions> : BuddyFixture<TOptions, Program> where TOptions : BuddyFixtureOptions<Program>, new();

--- a/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/Test/WithMockContainer/WithMockContainerTest.cs
+++ b/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/Test/WithMockContainer/WithMockContainerTest.cs
@@ -1,0 +1,24 @@
+using Adliance.AspNetCore.Buddy.Testing.Shared;
+using Xunit;
+
+namespace Adliance.AspNetCore.Buddy.Testing.v3.Test.Test.WithMockContainer;
+
+public class WithMockContainerTest(WithMockContainerFixture<InContainerOptions> fixture) : BaseTest<InContainerOptions>(fixture);
+
+public abstract class BaseTest<TOptions>(WithMockContainerFixture<TOptions> fixture)
+    : IClassFixture<WithMockContainerFixture<TOptions>>
+    where TOptions : BuddyFixtureOptions<Program>, new()
+{
+    [Fact]
+    public async Task Can_Access_Mock_Api()
+    {
+        var apiClient = fixture.InContainers.First().Client;
+
+        var response = await apiClient.GetAsync("/api/hello", TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        Assert.Equal("Hello from the mock API!", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
+}

--- a/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/api-mock.json
+++ b/test/Adliance.AspNetCore.Buddy.Testing.v3.Test/api-mock.json
@@ -1,0 +1,94 @@
+{
+  "uuid": "0d3fd903-cced-4f6a-b113-b9cbc3677bf0",
+  "lastMigration": 33,
+  "name": "Buddy Test API Mock",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3000,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "03a4c076-b7c7-4b3d-b6d7-8051297135d6",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/hello",
+      "responses": [
+        {
+          "uuid": "08c1ad9d-420c-4600-bb51-008f647072ec",
+          "body": "Hello from the mock API!",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "03a4c076-b7c7-4b3d-b6d7-8051297135d6"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "text/plain"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
+}


### PR DESCRIPTION
It is now possible to define a prebuilt container image via `ContainerOptions`. Furthermore, the container can be configured via a builder function before it is started. By default, client calls now time out after 10 seconds.